### PR TITLE
YSU clean up: remove unnecessary variables

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -69,6 +69,8 @@
 ! * after updating module_bl_ysu.F to WRF version 4.0.3, corrected call to subroutine ysu to output diagnostics of
 !   exchange coefficients exch_h and exch_m.
 !   Laura D. Fowler (laura@ucar.edu) / 2019-03-12.
+! * remove unnecessary "regime" field from YSU call
+!   Dave Gill (gill@ucar.edu) / 2019-08-05.
 
 
  contains
@@ -124,7 +126,6 @@
        if(.not.allocated(ctopo2_p)) allocate(ctopo2_p(ims:ime,jms:jme)      )
        if(.not.allocated(psih_p)  ) allocate(psih_p(ims:ime,jms:jme)        )
        if(.not.allocated(psim_p)  ) allocate(psim_p(ims:ime,jms:jme)        )
-       if(.not.allocated(regime_p)) allocate(regime_p(ims:ime,jms:jme)      )
        if(.not.allocated(u10_p)   ) allocate(u10_p(ims:ime,jms:jme)         )
        if(.not.allocated(v10_p)   ) allocate(v10_p(ims:ime,jms:jme)         )
        if(.not.allocated(exch_p)  ) allocate(exch_p(ims:ime,kms:kme,jms:jme))
@@ -212,7 +213,6 @@
        if(allocated(ctopo2_p)) deallocate(ctopo2_p)
        if(allocated(psih_p)  ) deallocate(psih_p  )
        if(allocated(psim_p)  ) deallocate(psim_p  )
-       if(allocated(regime_p)) deallocate(regime_p)
        if(allocated(u10_p)   ) deallocate(u10_p   )
        if(allocated(v10_p)   ) deallocate(v10_p   )
        if(allocated(exch_p)  ) deallocate(exch_p  )
@@ -341,7 +341,6 @@
           br_p(i,j)     = br(i)
           psim_p(i,j)   = fm(i)
           psih_p(i,j)   = fh(i)
-          regime_p(i,j) = regime(i)
           u10_p(i,j)    = u10(i)
           v10_p(i,j)    = v10(i)
           !initialization for YSU PBL scheme:
@@ -633,7 +632,7 @@
                  exch_m   = kzm_p      , wstar    = wstar_p     , delta    = delta_p    , &
                  uoce     = uoce_p     , voce     = voce_p      , rthraten = rthraten_p , &
                  u10      = u10_p      , v10      = v10_p       , ctopo    = ctopo_p    , &
-                 ctopo2   = ctopo2_p   , regime   = regime_p    ,                         &
+                 ctopo2   = ctopo2_p   ,                                                  &
                  ysu_topdown_pblmix = ysu_pblmix ,                                        &
                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -213,7 +213,6 @@ contains
                                                                        ctopo2
 !local
    integer ::  i,j,k
-   real,     dimension( its:ite, kts:kte )  ::                            pdh
    real,     dimension( its:ite, kts:kte+1 )  ::                         pdhi
    real,     dimension( its:ite )  ::                                          &
                                                                         dusfc, &
@@ -253,7 +252,6 @@ contains
    do j = jts,jte
       do k = kts,kte+1
         do i = its,ite
-          if(k.le.kte)pdh(i,k) = p3d(i,k,j)
           pdhi(i,k) = p3di(i,k,j)
         enddo
       enddo
@@ -262,7 +260,7 @@ contains
               ,tx=t3d(ims,kms,j)                                               &
               ,qvx=qv3d(ims,kms,j),qcx=qc3d(ims,kms,j),qix=qi3d(ims,kms,j)     &
               ,nmix=nmix,qmix=qmix(ims,kms,j,1)                                &
-              ,p2d=pdh(its,kts),p2di=pdhi(its,kts)                             &
+              ,p2d=p3d(ims,kms,j),p2di=pdhi(its,kts)                           &
               ,pi2d=pi3d(ims,kms,j)                                            &
               ,utnp=rublten(ims,kms,j),vtnp=rvblten(ims,kms,j)                 &
               ,ttnp=rthblten(ims,kms,j),qvtnp=rqvblten(ims,kms,j)              &
@@ -460,7 +458,7 @@ contains
    real,     dimension( its:ite, kts:kte+1 )                                 , &
              intent(in   )   ::                                          p2di
 !
-   real,     dimension( its:ite, kts:kte )                                   , &
+   real,     dimension( ims:ime, kms:kme )                                   , &
              intent(in   )   ::                                           p2d
 !
    real,     dimension( ims:ime )                                            , &

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -56,9 +56,7 @@ contains
                   ctopo,ctopo2,                                                &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
-                  its,ite, jts,jte, kts,kte,                                   &
-                !optional
-                  regime                                                       &
+                  its,ite, jts,jte, kts,kte                                    &
                  )
 !-------------------------------------------------------------------------------
    implicit none
@@ -205,12 +203,6 @@ contains
              intent(out  )   ::                                        kpbl2d
    logical,  intent(in)      ::                                       flag_qi
 !
-!optional
-!
-   real,     dimension( ims:ime, jms:jme )                                   , &
-             optional                                                        , &
-             intent(inout)   ::                                        regime
-!
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
              optional                                                        , &
              intent(inout)   ::                                       rqiblten
@@ -282,7 +274,7 @@ contains
               ,dz8w2d=dz8w(ims,kms,j)                                          &
               ,psfcpa=psfc(ims,j),znt=znt(ims,j),ust=ust(ims,j)                &
               ,hpbl=hpbl(ims,j)                                                &
-              ,regime=regime(ims,j),psim=psim(ims,j)                           &
+              ,psim=psim(ims,j)                                                &
               ,psih=psih(ims,j),xland=xland(ims,j)                             &
               ,hfx=hfx(ims,j),qfx=qfx(ims,j)                                   &
               ,wspd=wspd(ims,j),br=br(ims,j)                                   &
@@ -346,9 +338,7 @@ contains
                   ctopo,ctopo2,                                                &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
-                  its,ite, jts,jte, kts,kte,                                   &
-                !optional
-                  regime                                                       &
+                  its,ite, jts,jte, kts,kte                                    &
                    )
 !-------------------------------------------------------------------------------
    implicit none
@@ -499,9 +489,6 @@ contains
              optional                                                        , &
              intent(in   )   ::                                         ctopo, &
                                                                        ctopo2
-   real,     dimension( ims:ime )                                            , &
-             optional                                                        , &
-             intent(inout)   ::                                        regime
 !
 ! local vars
 !

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -213,7 +213,6 @@ contains
                                                                        ctopo2
 !local
    integer ::  i,j,k
-   real,     dimension( its:ite, kts:kte+1 )  ::                         pdhi
    real,     dimension( its:ite )  ::                                          &
                                                                         dusfc, &
                                                                         dvsfc, &
@@ -250,17 +249,12 @@ contains
  enddo
 !
    do j = jts,jte
-      do k = kts,kte+1
-        do i = its,ite
-          pdhi(i,k) = p3di(i,k,j)
-        enddo
-      enddo
 !
       call ysu2d(J=j,ux=u3d(ims,kms,j),vx=v3d(ims,kms,j)                       &
               ,tx=t3d(ims,kms,j)                                               &
               ,qvx=qv3d(ims,kms,j),qcx=qc3d(ims,kms,j),qix=qi3d(ims,kms,j)     &
               ,nmix=nmix,qmix=qmix(ims,kms,j,1)                                &
-              ,p2d=p3d(ims,kms,j),p2di=pdhi(its,kts)                           &
+              ,p2d=p3d(ims,kms,j),p2di=p3di(ims,kms,j)                         &
               ,pi2d=pi3d(ims,kms,j)                                            &
               ,utnp=rublten(ims,kms,j),vtnp=rvblten(ims,kms,j)                 &
               ,ttnp=rthblten(ims,kms,j),qvtnp=rqvblten(ims,kms,j)              &
@@ -454,7 +448,7 @@ contains
    real,     dimension( ims:ime, kms:kme, nmix )                             , &
              intent(inout), optional   ::                             qmixtnp
 !
-   real,     dimension( its:ite, kts:kte+1 )                                 , &
+   real,     dimension( ims:ime, kms:kme )                                   , &
              intent(in   )   ::                                          p2di
 !
    real,     dimension( ims:ime, kms:kme )                                   , &

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -133,7 +133,6 @@ contains
 !-- kte         end index for k in tile
 !-------------------------------------------------------------------------------
 !
-   real,parameter    ::  rcl = 1.0
 !
    integer,  intent(in   )   ::      ids,ide, jds,jde, kds,kde,                &
                                      ims,ime, jms,jme, kms,kme,                &
@@ -266,7 +265,7 @@ contains
               ,psih=psih(ims,j),xland=xland(ims,j)                             &
               ,hfx=hfx(ims,j),qfx=qfx(ims,j)                                   &
               ,wspd=wspd(ims,j),br=br(ims,j)                                   &
-              ,dt=dt,rcl=1.0,kpbl1d=kpbl2d(ims,j)                              &
+              ,dt=dt,kpbl1d=kpbl2d(ims,j)                                      &
               ,exch_hx=exch_h(ims,kms,j)                                       &
               ,exch_mx=exch_m(ims,kms,j)                                       &
               ,wstar=wstar(ims,j)                                              &
@@ -314,7 +313,7 @@ contains
                   dz8w2d,psfcpa,                                               &
                   znt,ust,hpbl,psim,psih,                                      &
                   xland,hfx,qfx,wspd,br,                                       &
-                  dt,rcl,kpbl1d,                                               &
+                  dt,kpbl1d,                                                   &
                   exch_hx,exch_mx,                                             &
                   wstar,delta,                                                 &
                   u10,v10,                                                     &
@@ -400,6 +399,7 @@ contains
    real,parameter    ::  gamcrt = 3.,gamcrq = 2.e-3
    real,parameter    ::  xka = 2.4e-5
    integer,parameter ::  imvdif = 1
+   real,parameter    ::  rcl = 1.0
 !
    integer,  intent(in   )   ::     ids,ide, jds,jde, kds,kde,                 &
                                     ims,ime, jms,jme, kms,kme,                 &
@@ -410,7 +410,7 @@ contains
 !
    integer,  intent(in)      ::     nmix
 !
-   real,     intent(in   )   ::     dt,rcl,cp,g,rovcp,rovg,rd,xlv,rv
+   real,     intent(in   )   ::     dt,cp,g,rovcp,rovg,rd,xlv,rv
 !
    real,     intent(in )     ::     ep1,ep2,karman
 !

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -213,11 +213,7 @@ contains
                                                                        ctopo2
 !local
    integer ::  i,j,k
-   real,     dimension( its:ite )  ::                                          &
-                                                                        dusfc, &
-                                                                        dvsfc, &
-                                                                        dtsfc, &
-                                                                        dqsfc
+
 !temporary allocation of local chemical species and/or passive tracers that are vertically-
 !mixed in subroutine ysu2d:
    integer,  parameter :: nmix = 5
@@ -270,7 +266,6 @@ contains
               ,psih=psih(ims,j),xland=xland(ims,j)                             &
               ,hfx=hfx(ims,j),qfx=qfx(ims,j)                                   &
               ,wspd=wspd(ims,j),br=br(ims,j)                                   &
-              ,dusfc=dusfc,dvsfc=dvsfc,dtsfc=dtsfc,dqsfc=dqsfc                 &
               ,dt=dt,rcl=1.0,kpbl1d=kpbl2d(ims,j)                              &
               ,exch_hx=exch_h(ims,kms,j)                                       &
               ,exch_mx=exch_m(ims,kms,j)                                       &
@@ -319,7 +314,6 @@ contains
                   dz8w2d,psfcpa,                                               &
                   znt,ust,hpbl,psim,psih,                                      &
                   xland,hfx,qfx,wspd,br,                                       &
-                  dusfc,dvsfc,dtsfc,dqsfc,                                     &
                   dt,rcl,kpbl1d,                                               &
                   exch_hx,exch_mx,                                             &
                   wstar,delta,                                                 &

--- a/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_bl_ysu.F
@@ -284,7 +284,7 @@ contains
               ,delta=delta(ims,j)                                              &
               ,u10=u10(ims,j),v10=v10(ims,j)                                   &
               ,uox=uoce(ims,j),vox=voce(ims,j)                                 &
-              ,rthraten=rthraten(ims,kms,j),p2diORG=p3di(ims,kms,j)            &
+              ,rthraten=rthraten(ims,kms,j)                                    &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo(ims,j),ctopo2=ctopo2(ims,j)                         &
               ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
@@ -331,7 +331,7 @@ contains
                   wstar,delta,                                                 &
                   u10,v10,                                                     &
                   uox,vox,                                                     &
-                  rthraten,p2diORG,                                            &
+                  rthraten,                                                    &
                   ysu_topdown_pblmix,                                          &
                   ctopo,ctopo2,                                                &
                   ids,ide, jds,jde, kds,kde,                                   &
@@ -428,8 +428,7 @@ contains
 !
    real,     dimension( ims:ime, kms:kme ),                                    &
              intent(in)      ::                                        dz8w2d, &
-                                                                         pi2d, &
-                                                                      p2diorg
+                                                                         pi2d
 !
    real,     dimension( ims:ime, kms:kme )                                   , &
              intent(in   )   ::                                            tx, &
@@ -1008,7 +1007,7 @@ contains
                 radsum=0.
                 do kk = 1,kpbl(i)-1
                    radflux=rthraten(i,kk)*pi2d(i,kk) !converts theta/s to temp/s
-                   radflux=radflux*cp/g*(p2diORG(i,kk)-p2diORG(i,kk+1)) ! converts temp/s to W/m^2
+                   radflux=radflux*cp/g*(p2di(i,kk)-p2di(i,kk+1)) ! converts temp/s to W/m^2
                    if (radflux < 0.0 ) radsum=abs(radflux)+radsum
                 enddo
                 radsum=max(radsum,0.0)


### PR DESCRIPTION
In anticipation of moving to a shared physics interface, these modifications remove unused
and generally unnecessary variables that are passed from the YSU scheme into YSU2D. Getting
rid of redundant fields for the scheme that is targeted to be the CPF interface will make the 
construction of the CPF physics metadata file easier.

Able to get bit-for-bit results with standard global 40962 case, comparing my mods to the code
with the hash just prior my mods.