### PR TITLE
YSU CPF: INTENTs, inits; errmsg etc; add metadata file; 

### DIFF
--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -850,6 +850,9 @@ module atm_core
       integer :: s, s_n, s_d
       real (kind=RKIND) :: xtime_s
       integer :: ierr
+      
+      character(len=StrKIND) :: errmsg
+      integer :: errflg
 
       clock => domain % clock
       mpas_log_info => domain % logInfo
@@ -866,7 +869,10 @@ module atm_core
       !proceed with physics if moist_physics is set to true:
       if(moist_physics) then
          call physics_timetracker(domain,dt,clock,itimestep,xtime_s)
-         call physics_driver(domain,itimestep,xtime_s)
+         call physics_driver(domain,itimestep,xtime_s,errmsg,errflg)
+         if ( errflg /= 0 ) then
+            call mpas_log_write('Physics failed: '//trim(errmsg), messageType=MPAS_LOG_CRIT)
+         end if
       endif
 #endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -103,7 +103,7 @@
 
 
 !=================================================================================================================
- subroutine physics_driver(domain,itimestep,xtime_s)
+ subroutine physics_driver(domain,itimestep,xtime_s,errmsg,errflg)
 !=================================================================================================================
 
 !input arguments:
@@ -112,6 +112,10 @@
 
 !inout arguments:
  type(domain_type),intent(inout):: domain
+
+!out arguments:
+ character(len=*), intent(out):: errmsg
+ integer,          intent(out):: errflg
 
 !local pointers:
  type(mpas_pool_type),pointer::  configs,      &
@@ -286,7 +290,8 @@
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call driver_pbl(itimestep,block%configs,mesh,sfc_input,diag_physics,tend_physics, &
-                          cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
+                          cellSolveThreadStart(thread),cellSolveThreadEnd(thread), &
+                          errmsg,errflg)
        end do
 !$OMP END PARALLEL DO
        call deallocate_pbl(block%configs)

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -621,18 +621,18 @@
                  qv3d     = qv_p       , qc3d     = qc_p        , qi3d     = qi_p       , &
                  rublten  = rublten_p  , rvblten  = rvblten_p   , rthblten = rthblten_p , &
                  rqvblten = rqvblten_p , rqcblten = rqcblten_p  , rqiblten = rqiblten_p , & 
-                 flag_qi  = f_qi       , cp       = cp          , g        = gravity    , &
-                 rovcp    = rcp        , rd       = R_d         , rovg     = rdg        , & 
-                 ep1      = ep_1       , ep2      = ep_2        , karman   = karman     , &
-                 xlv      = xlv        , rv       = R_v         , znt      = znt_p      , &
-                 ust      = ust_p      , hpbl     = hpbl_p      , psim     = psim_p     , &
-                 psih     = psih_p     , xland    = xland_p     , hfx      = hfx_p      , &
-                 qfx      = qfx_p      , wspd     = wspd_p      , br       = br_p       , &
-                 dt       = dt_pbl     , kpbl2d   = kpbl_p      , exch_h   = kzh_p      , &
-                 exch_m   = kzm_p      , wstar    = wstar_p     , delta    = delta_p    , &
-                 uoce     = uoce_p     , voce     = voce_p      , rthraten = rthraten_p , &
-                 u10      = u10_p      , v10      = v10_p       , ctopo    = ctopo_p    , &
-                 ctopo2   = ctopo2_p   ,                                                  &
+                 flag_qc  = f_qc       , flag_qi  = f_qi        , cp       = cp         , &
+                 g        = gravity    , rovcp    = rcp         , rd       = R_d        , &
+                 rovg     = rdg        , ep1      = ep_1        , ep2      = ep_2       , &
+                 karman   = karman     , xlv      = xlv         , rv       = R_v        , &
+                 znt      = znt_p      , ust      = ust_p       , hpbl     = hpbl_p     , &
+                 psim     = psim_p     , psih     = psih_p      , xland    = xland_p    , & 
+                 hfx      = hfx_p      , qfx      = qfx_p       , wspd     = wspd_p     , &
+                 br       = br_p       , dt       = dt_pbl      , kpbl2d   = kpbl_p     , &
+                 exch_h   = kzh_p      , exch_m   = kzm_p       , wstar    = wstar_p    , & 
+                 delta    = delta_p    , uoce     = uoce_p      , voce     = voce_p     , &
+                 rthraten = rthraten_p , u10      = u10_p       , v10      = v10_p      , &
+                 ctopo    = ctopo_p    , ctopo2   = ctopo2_p    ,                         &
                  ysu_topdown_pblmix = ysu_pblmix ,                                        &
                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
@@ -574,7 +574,8 @@
  end subroutine pbl_to_MPAS
  
 !=================================================================================================================
- subroutine driver_pbl(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite)
+ subroutine driver_pbl(itimestep,configs,mesh,sfc_input,diag_physics,tend_physics,its,ite, &
+                       errmsg,errflg)
 !=================================================================================================================
 
 !input arguments:
@@ -588,6 +589,11 @@
  type(mpas_pool_type),intent(inout):: sfc_input
  type(mpas_pool_type),intent(inout):: diag_physics
  type(mpas_pool_type),intent(inout):: tend_physics
+
+!out arguments:
+ character(len=*),intent(out):: errmsg
+ integer,         intent(out):: errflg
+
 
 !local pointers:
  logical,pointer:: config_do_restart
@@ -634,6 +640,7 @@
                  rthraten = rthraten_p , u10      = u10_p       , v10      = v10_p      , &
                  ctopo    = ctopo_p    , ctopo2   = ctopo2_p    ,                         &
                  ysu_topdown_pblmix = ysu_pblmix ,                                        &
+                 errmsg   = errmsg     , errflg   = errflg      ,                         &
                  ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde  , &
                  ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme  , &
                  its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte    &

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -34,7 +34,21 @@
 !
 !
 module bl_ysu
-use mpas_log
+
+  use mpas_log
+  !USE ccpp_kinds, ONLY: kind_phys
+
+  IMPLICIT NONE
+
+  PUBLIC :: bl_ysu_init
+  PUBLIC :: bl_ysu_run
+  PUBLIC :: bl_ysu_finalize
+
+  PRIVATE :: ysu
+  PRIVATE :: tridi1n
+  PRIVATE :: tridin_ysu
+  PRIVATE :: get_pblh
+
 contains
 !
 !
@@ -378,7 +392,7 @@ contains
               ,rthraten=rthraten_hv                                            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo_hv,ctopo2=ctopo2_hv                                 &
-              ,its=its,ite=ite, kts=kts,kte=kte                                &
+              ,its=its,ite=ite, kts=kts,kte=kte, kms=kms,kme=kme               &
               ,errmsg=errmsg,errflg=errflg                                     )
 !
       !  Assign local data back to full-sized arrays.
@@ -442,6 +456,10 @@ contains
 !
 !-------------------------------------------------------------------------------
 !
+
+!> \section arg_table_bl_ysu_run  Argument Table
+!! \htmlinclude arg_table_bl_ysu_run.html
+!!
    subroutine bl_ysu_run(j,ux,vx,tx,qvx,qcx,qix,nmix,qmix,p2d,p2di,pi2d,       &
                   f_qc,f_qi,                                                   &
                   utnp,vtnp,ttnp,qvtnp,qctnp,qitnp,qmixtnp,                    &
@@ -457,7 +475,7 @@ contains
                   rthraten,                                                    &
                   ysu_topdown_pblmix,                                          &
                   ctopo,ctopo2,                                                &
-                  its,ite, kts,kte,                                            &
+                  its,ite, kts,kte, kms,kme,                                   &
                   errmsg,errflg                                                &
                    )
 !-------------------------------------------------------------------------------
@@ -536,8 +554,7 @@ contains
    integer,parameter ::  imvdif = 1
    real,parameter    ::  rcl = 1.0
 !
-   integer,  intent(in   )   ::     its,ite, kts,kte,                          &
-                                    j
+   integer,  intent(in   )   ::     its,ite, kts,kte, kms,kme, j
 
    integer,  intent(in)      ::     ysu_topdown_pblmix 
 !
@@ -573,7 +590,7 @@ contains
    real,     dimension( its:ite, kts:kte, nmix )                             , &
              intent(out  )   ::                                       qmixtnp
 !
-   real,     dimension( its:ite, kts:kte+1 )                                 , &
+   real,     dimension( its:ite, kms:kme )                                   , &
              intent(in   )   ::                                          p2di
 !
    real,     dimension( its:ite, kts:kte )                                   , &
@@ -615,7 +632,7 @@ contains
 ! local vars
 !
    real,     dimension( its:ite )            ::                           hol
-   real,     dimension( its:ite, kts:kte+1 ) ::                            zq
+   real,     dimension( its:ite, kms:kme )   ::                            zq
 !
    real,     dimension( its:ite, kts:kte )   ::                                &
                                                                thx,thvx,thlix, &
@@ -720,7 +737,7 @@ contains
                                                                       vconvfx
 
    real,     dimension( kts:kte )   :: dummy1,dummy2,dummy4
-   real,     dimension( kts:kte+1 ) :: dummy3
+   real,     dimension( kms:kme )   :: dummy3
 !
 !-------------------------------------------------------------------------------
 !
@@ -1657,6 +1674,36 @@ contains
    errflg = 0
 !
    end subroutine bl_ysu_run
+
+!> \section arg_table_bl_ysu_init  Argument Table
+!! \htmlinclude arg_table_bl_ysu_init.html
+!!
+  subroutine bl_ysu_init (errmsg, errflg)
+
+    character(len=*),        intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine bl_ysu_init
+
+!> \section arg_table_bl_ysu_finalize  Argument Table
+!! \htmlinclude arg_table_bl_ysu_finalize.html
+!!
+  subroutine bl_ysu_finalize (errmsg, errflg)
+
+    character(len=*),        intent(out)   :: errmsg
+    integer,                 intent(out)   :: errflg
+
+    ! This routine currently does nothing
+
+    errmsg = ''
+    errflg = 0
+
+  end subroutine bl_ysu_finalize
 !-------------------------------------------------------------------------------
 !
 !-------------------------------------------------------------------------------

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -42,7 +42,7 @@ contains
 !
    subroutine ysu(u3d,v3d,th3d,t3d,qv3d,qc3d,qi3d,p3d,p3di,pi3d,               &
                   rublten,rvblten,rthblten,                                    &
-                  rqvblten,rqcblten,rqiblten,flag_qi,                          &
+                  rqvblten,rqcblten,rqiblten,flag_qc,flag_qi,                  &
                   cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
                   dz8w,psfc,                                                   &
                   znt,ust,hpbl,psim,psih,                                      &
@@ -158,19 +158,20 @@ contains
              intent(in   )   ::                                          p3di
 !
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
-             intent(inout)   ::                                       rublten, &
+             intent(out  )   ::                                       rublten, &
                                                                       rvblten, &
                                                                      rthblten, &
                                                                      rqvblten, &
-                                                                     rqcblten
+                                                                     rqcblten, &
+                                                                     rqiblten
 !
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
              intent(inout)   ::                                        exch_h, &
                                                                        exch_m
    real,     dimension( ims:ime, jms:jme )                                   , &
-             intent(inout)   ::                                         wstar
+             intent(out  )   ::                                         wstar
    real,     dimension( ims:ime, jms:jme )                                   , &
-             intent(inout)   ::                                         delta
+             intent(out  )   ::                                         delta
    real,     dimension( ims:ime, jms:jme )                                   , &
              intent(inout)   ::                                           u10, &
                                                                           v10
@@ -189,10 +190,11 @@ contains
                                                                          psim, &
                                                                          psih
    real,     dimension( ims:ime, jms:jme )                                   , &
-             intent(inout)   ::                                           znt, &
+             intent(in   )   ::                                           znt, &
                                                                           ust, &
-                                                                         hpbl, &
                                                                           wspd
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(out  )   ::                                          hpbl
 !
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
              intent(in   )   ::                                           u3d, &
@@ -200,11 +202,9 @@ contains
 !
    integer,  dimension( ims:ime, jms:jme )                                   , &
              intent(out  )   ::                                        kpbl2d
-   logical,  intent(in)      ::                                       flag_qi
 !
-   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
-             optional                                                        , &
-             intent(inout)   ::                                       rqiblten
+   logical,  intent(in)      ::                                       flag_qc, &
+                                                                      flag_qi
 !
    real,     dimension( ims:ime, jms:jme )                                   , &
              optional                                                        , &
@@ -219,9 +219,6 @@ contains
    integer :: n
    real,     dimension ( ims:ime, kms:kme, jms:jme, nmix) ::             qmix
    real,     dimension ( ims:ime, kms:kme, jms:jme, nmix) ::       rqmixblten
-! 
-   logical ::                                                            f_qc, &
-                                                                         f_qi
 
    !  Local tile-sized arrays for contiguous data for bl_ysu_run call.
       
@@ -282,41 +279,17 @@ contains
        do i = its, ite
           n = 1
           qmix(i,k,j,n) = 0.
-          rqmixblten(i,k,j,n) = 0.
           n = 2
           qmix(i,k,j,n) = 0.25
-          rqmixblten(i,k,j,n) = 0.
           n = 3
           qmix(i,k,j,n) = 0.50
-          rqmixblten(i,k,j,n) = 0.
           n = 4
           qmix(i,k,j,n) = 0.75
-          rqmixblten(i,k,j,n) = 0.
           n = 5
           qmix(i,k,j,n) = 1.
-          rqmixblten(i,k,j,n) = 0.
        enddo
    enddo
  enddo
-!
-   f_qc = .true.
-   f_qi = .true.
-!
-!
-!-----initialize vertical mixing tendencies
-!
-   do j = jts, jte
-      do k = kts, kte
-         do i = its, ite
-            rublten(i,k,j)    = 0.
-            rvblten(i,k,j)    = 0.
-            rthblten(i,k,j)   = 0.
-            rqvblten(i,k,j)   = 0.
-            rqcblten(i,k,j)   = 0.
-            rqiblten(i,k,j)   = 0.
-         enddo
-      enddo
-   enddo
 !
    do j = jts,jte
 !
@@ -326,7 +299,6 @@ contains
          do k = kts, kte
             do i = its, ite
                qmix_hv(i,k,n) = qmix(i,k,j,n)
-               rqmixblten_hv(i,k,n) = rqmixblten(i,k,j,n)
             end do
          end do
       end do
@@ -347,12 +319,6 @@ contains
             qi3d_hv(i,k) = qi3d(i,k,j)
             p3d_hv(i,k) = p3d(i,k,j)
             pi3d_hv(i,k) = pi3d(i,k,j)
-            rublten_hv(i,k) = rublten(i,k,j)
-            rvblten_hv(i,k) = rvblten(i,k,j)
-            rthblten_hv(i,k) = rthblten(i,k,j)
-            rqvblten_hv(i,k) = rqvblten(i,k,j)
-            rqcblten_hv(i,k) = rqcblten(i,k,j)
-            rqiblten_hv(i,k) = rqiblten(i,k,j)
             dz8w_hv(i,k) = dz8w(i,k,j)
             exch_h_hv(i,k) = exch_h(i,k,j)
             exch_m_hv(i,k) = exch_m(i,k,j)
@@ -364,17 +330,14 @@ contains
          psfc_hv(i) = psfc(i,j)
          znt_hv(i) = znt(i,j)
          ust_hv(i) = ust(i,j)
-         hpbl_hv(i) = hpbl(i,j)
+         wspd_hv(i) = wspd(i,j)
          psim_hv(i) = psim(i,j)
          psih_hv(i) = psih(i,j)
          xland_hv(i) = xland(i,j)
          hfx_hv(i) = hfx(i,j)
          qfx_hv(i) = qfx(i,j)
-         wspd_hv(i) = wspd(i,j)
          br_hv(i) = br(i,j)
          kpbl2d_hv(i) = kpbl2d(i,j)
-         wstar_hv(i) = wstar(i,j)
-         delta_hv(i) = delta(i,j)
          u10_hv(i) = u10(i,j)
          v10_hv(i) = v10(i,j)
          uoce_hv(i) = uoce(i,j)
@@ -386,7 +349,7 @@ contains
       call bl_ysu_run(J=j,ux=u3d_hv,vx=v3d_hv                                  &
               ,tx=t3d_hv                                                       &
               ,qvx=qv3d_hv,qcx=qc3d_hv,qix=qi3d_hv                             &
-              ,f_qc=f_qc,f_qi=f_qi                                             &
+              ,f_qc=flag_qc,f_qi=flag_qi                                       &
               ,nmix=nmix,qmix=qmix_hv                                          &
               ,p2d=p3d_hv,p2di=p3di_hv                                         &
               ,pi2d=pi3d_hv                                                    &
@@ -441,9 +404,6 @@ contains
       end do
       
       do i = its, ite
-         ust(i,j) = ust_hv(i)
-         znt(i,j) = znt_hv(i)
-         wspd(i,j) = wspd_hv(i)
          u10(i,j) = u10_hv(i)
          v10(i,j) = v10_hv(i)
          hpbl(i,j) = hpbl_hv(i)
@@ -600,7 +560,7 @@ contains
              intent(in   )   ::                                          qmix
 !
    real,     dimension( its:ite, kts:kte )                                   , &
-             intent(inout)   ::                                          utnp, &
+             intent(out  )   ::                                          utnp, &
                                                                          vtnp, &
                                                                          ttnp, &
                                                                         qvtnp, &
@@ -608,7 +568,7 @@ contains
                                                                         qitnp
 !
    real,     dimension( its:ite, kts:kte, nmix )                             , &
-             intent(inout)   ::                                       qmixtnp
+             intent(out  )   ::                                       qmixtnp
 !
    real,     dimension( its:ite, kts:kte+1 )                                 , &
              intent(in   )   ::                                          p2di
@@ -617,15 +577,17 @@ contains
              intent(in   )   ::                                           p2d
 !
    real,     dimension( its:ite )                                            , &
-             intent(inout)   ::                                           ust, &
-                                                                         hpbl, &
+             intent(out  )   ::                                          hpbl
+!
+   real,     dimension( its:ite )                                            , &
+             intent(in   )   ::                                           ust, &
                                                                           znt
    real,     dimension( its:ite )                                            , &
              intent(in   )   ::                                         xland, &
                                                                           hfx, &
                                                                           qfx
 !
-   real,     dimension( its:ite ), intent(inout)   ::                    wspd
+   real,     dimension( its:ite ), intent(in   )   ::                    wspd
    real,     dimension( its:ite ), intent(in  )    ::                      br
 !
    real,     dimension( its:ite ), intent(in   )   ::                    psim, &
@@ -721,8 +683,8 @@ contains
 !
 
    real, dimension( its:ite, kts:kte )     ::                wscalek,wscalek2
-   real, dimension( its:ite )              ::                           wstar
-   real, dimension( its:ite )              ::                           delta
+   real, dimension( its:ite ), intent(out) ::                           wstar, &
+                                                                        delta
    real, dimension( its:ite, kts:kte )     ::                     xkzml,xkzhl, &
                                                                zfacent,entfac
    real, dimension( its:ite, kts:kte )     ::                            qcxl, &
@@ -880,7 +842,6 @@ contains
      vfxpbl(i) = 0.0
      hgamu(i)  = 0.0
      hgamv(i)  = 0.0
-     delta(i)  = 0.0
      wstar3_2(i) =  0.0
    enddo
 !
@@ -1402,7 +1363,7 @@ contains
    do k = kte,kts,-1
      do i = its,ite
        ttend = (f1(i,k)-thx(i,k)+300.)*rdt*pi2d(i,k)
-       ttnp(i,k) = ttnp(i,k)+ttend
+       ttnp(i,k) = ttend
        dtsfc(i) = dtsfc(i)+ttend*cont*del(i,k)/pi2d(i,k)
      enddo
    enddo
@@ -1467,7 +1428,7 @@ contains
    do i = its,ite
       do k = kte,kts,-1
          qtend = (f1(i,k)-qvx(i,k))*rdt
-         qvtnp(i,k) = qvtnp(i,k)+qtend
+         qvtnp(i,k) = qtend
          dqsfc(i)   = dqsfc(i)+qtend*conq*del(i,k)
       enddo
    enddo
@@ -1485,7 +1446,7 @@ contains
       do i = its,ite
          do k = kte,kts,-1
             qtend = (f1(i,k)-qcxl(i,k))*rdt
-            qctnp(i,k) = qctnp(i,k)+qtend
+            qctnp(i,k) = qtend
          enddo
       enddo
    endif
@@ -1503,7 +1464,7 @@ contains
       do i = its,ite
          do k = kte,kts,-1
             qtend = (f1(i,k)-qixl(i,k))*rdt
-            qitnp(i,k) = qitnp(i,k)+qtend
+            qitnp(i,k) = qtend
          enddo
       enddo
    endif
@@ -1523,7 +1484,7 @@ contains
          do i = its,ite
             do k = kte,kts,-1
                qtend = (f1(i,k)-qmix(i,k,n))*rdt
-               qmixtnp(i,k,n) = qmixtnp(i,k,n)+qtend
+               qmixtnp(i,k,n) = qtend
             enddo
          enddo
       enddo
@@ -1663,8 +1624,8 @@ contains
      do i = its,ite
        utend = (f1(i,k)-ux(i,k))*rdt
        vtend = (f2(i,k)-vx(i,k))*rdt
-       utnp(i,k) = utnp(i,k)+utend
-       vtnp(i,k) = vtnp(i,k)+vtend
+       utnp(i,k) = utend
+       vtnp(i,k) = vtend
        dusfc(i) = dusfc(i) + utend*conwrc*del(i,k)
        dvsfc(i) = dvsfc(i) + vtend*conwrc*del(i,k)
      enddo

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -56,7 +56,8 @@ contains
                   ctopo,ctopo2,                                                &
                   ids,ide, jds,jde, kds,kde,                                   &
                   ims,ime, jms,jme, kms,kme,                                   &
-                  its,ite, jts,jte, kts,kte                                    &
+                  its,ite, jts,jte, kts,kte,                                   &
+                  errmsg,errflg                                                &
                  )
 !-------------------------------------------------------------------------------
    implicit none
@@ -210,6 +211,9 @@ contains
              optional                                                        , &
              intent(in   )   ::                                         ctopo, &
                                                                        ctopo2
+!
+   character(len=*), intent(out)   ::                                  errmsg
+   integer,          intent(out)   ::                                  errflg
 !local
    integer ::  i,j,k
 
@@ -374,7 +378,8 @@ contains
               ,rthraten=rthraten_hv                                            &
               ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
               ,ctopo=ctopo_hv,ctopo2=ctopo2_hv                                 &
-              ,its=its,ite=ite, kts=kts,kte=kte                                )
+              ,its=its,ite=ite, kts=kts,kte=kte                                &
+              ,errmsg=errmsg,errflg=errflg                                     )
 !
       !  Assign local data back to full-sized arrays.
       !  Only required for the INTENT(OUT) or INTENT(INOUT) arrays.
@@ -452,7 +457,8 @@ contains
                   rthraten,                                                    &
                   ysu_topdown_pblmix,                                          &
                   ctopo,ctopo2,                                                &
-                  its,ite, kts,kte                                             &
+                  its,ite, kts,kte,                                            &
+                  errmsg,errflg                                                &
                    )
 !-------------------------------------------------------------------------------
    implicit none
@@ -601,6 +607,10 @@ contains
              optional                                                        , &
              intent(in   )   ::                                         ctopo, &
                                                                        ctopo2
+!
+   character(len=*), intent(out)   ::                                  errmsg
+   integer,          intent(out)   ::                                  errflg
+
 !
 ! local vars
 !
@@ -1642,6 +1652,9 @@ contains
    do i = its,ite
      kpbl1d(i) = kpbl(i)
    enddo
+!
+   errmsg = 'bl_ysu_run OK'
+   errflg = 0
 !
    end subroutine bl_ysu_run
 !-------------------------------------------------------------------------------

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -166,7 +166,7 @@ contains
                                                                      rqiblten
 !
    real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
-             intent(inout)   ::                                        exch_h, &
+             intent(out  )   ::                                        exch_h, &
                                                                        exch_m
    real,     dimension( ims:ime, jms:jme )                                   , &
              intent(out  )   ::                                         wstar
@@ -320,8 +320,6 @@ contains
             p3d_hv(i,k) = p3d(i,k,j)
             pi3d_hv(i,k) = pi3d(i,k,j)
             dz8w_hv(i,k) = dz8w(i,k,j)
-            exch_h_hv(i,k) = exch_h(i,k,j)
-            exch_m_hv(i,k) = exch_m(i,k,j)
             rthraten_hv(i,k) = rthraten(i,k,j)
          end do
       end do
@@ -337,7 +335,6 @@ contains
          hfx_hv(i) = hfx(i,j)
          qfx_hv(i) = qfx(i,j)
          br_hv(i) = br(i,j)
-         kpbl2d_hv(i) = kpbl2d(i,j)
          u10_hv(i) = u10(i,j)
          v10_hv(i) = v10(i,j)
          uoce_hv(i) = uoce(i,j)

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.meta
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.meta
@@ -1,0 +1,548 @@
+[ccpp-arg-table]
+  name = bl_ysu_run
+  type = scheme
+[j]
+  standard_name = second_horiz_index
+  long_name = second horiz index
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ux]
+  standard_name = x_wind
+  long_name = x wind
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys | kind = kind_phys
+  intent = in
+  optional = F
+[vx]
+  standard_name = y_wind
+  long_name = y wind
+  units =  m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys | kind = kind_phys
+  intent = in
+  optional = F
+[tx]
+  standard_name = air_temperature
+  long_name = air temperature
+  units =  K
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[qvx]
+  standard_name = water_vapor_mixing_ratio
+  long_name = water vapor mixing ratio
+  units = kg kg-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[qcx]
+  standard_name = cloud_condensed_water_mixing_ratio
+  long_name = cloud condensed water mixing ratio
+  units = kg kg-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[qix]
+  standard_name = ice_water_mixing_ratio
+  long_name = ice water mixing ratio
+  units = kg kg-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[nmix]
+  standard_name = number_of_scalar_tracers
+  long_name = number of scalar tracers
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[qmix]
+  standard_name = scalars
+  long_name = scalars
+  units = kg kg-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end,number_of_scalar_tracers)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[p2d]
+  standard_name = air_pressure
+  long_name = air pressure
+  units = Pa
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[p2di]
+  standard_name = air_pressure_at_interface
+  long_name = air pressure at interface
+  units = Pa 
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_interface_start:vertical_interface_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[pi2d]
+  standard_name = dimensionless_exner_function
+  long_name = dimensionless exner function
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[f_qc]
+  standard_name = flag_for_cloud_water_mixing_ratio
+  long_name = flag for cloud water mixing ratio
+  units = none 
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[f_qi]
+  standard_name = flag_for_ice_water_mixing_ratio
+  long_name = flag for ice water mixing ratio
+  units = none 
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[utnp]
+  standard_name = tendency_of_x_wind_due_to_boundary_layer
+  long_name = tendency of x wind due to boundary layer
+  units = m s-2
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[vtnp]
+  standard_name = tendency_of_y_wind_due_to_boundary_layer
+  long_name = tendency of y wind due to boundary layer
+  units = m s-2
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[ttnp]
+  standard_name = tendency_of_potential_temperature_due_to_boundary_layer
+  long_name = tendency of potential temperature due to boundary layer
+  units =  K s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[qvtnp]
+  standard_name = tendency_of_water_vapor_mixing_ratio_due_to_boundary_layer
+  long_name = tendency of water vapor mixing ratio due to boundary layer
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[qctnp]
+  standard_name = tendency_of_cloud_water_mixing_ratio_due_to_boundary_layer
+  long_name = tendency of cloud water mixing ratio due to boundary layer
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[qitnp]
+  standard_name = tendency_of_ice_water_mixing_ratio_due_to_boundary_layer
+  long_name = tendency of ice water mixing ratio due to boundary layer
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[qmixtnp]
+  standard_name = tendency_of_scalars_due_to_boundary_layer
+  long_name = tendency of scalars due to boundary layer
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end,number_of_scalar_tracers)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[cp]
+  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  long_name = specific heat of dry air at constant pressure
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[g]
+  standard_name = gravitational_acceleration
+  long_name = gravitational acceleration
+  units = m s-2
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[rovcp]
+  standard_name = r_over_cp
+  long_name = r over cp
+  units =  none
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[rd]
+  standard_name = gas_constant_for_dry_air
+  long_name = gas constant for dry air
+  units = J kg-1 K-1 
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[rovg]
+  standard_name = r_over_g
+  long_name = r over g
+  units = m K-1 
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[ep1]
+  standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
+  long_name = ratio of vapor to dry air gas constants minus one
+  units = none
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[ep2]
+  standard_name = ratio_of_dry_air_to_water_vapor_gas_constants
+  long_name = ratio of dry air to water vapor gas constants
+  units = none
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[karman]
+  standard_name = vonKarman_constant
+  long_name = vonKarman constant
+  units = none
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[xlv]
+  standard_name = latent_heat_of_vaporization_of_water_at_0C
+  long_name = latent heat of vaporization of water at 0C
+  units = J kg-1
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[rv]
+  standard_name = gas_constant_for_water_vapor
+  long_name = gas constant for water vapor
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[dz8w2d]
+  standard_name = layer_thickness
+  long_name = layer thickness
+  units = m
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[psfcpa]
+  standard_name = surface_air_pressure
+  long_name = surface air pressure
+  units = Pa
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[znt]
+  standard_name = surface_roughness_length
+  long_name = surface roughness length
+  units = m
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[ust]
+  standard_name = surface_friction_velocity
+  long_name = surface friction velocity
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[hpbl]
+  standard_name = atmosphere_boundary_layer_thickness
+  long_name = atmosphere boundary layer thickness
+  units = m
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[psim]
+  standard_name = Monin_Obukhov_similarity_function_for_momentum
+  long_name = Monin-Obukhov similarity function for momentum
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[psih]
+  standard_name = Monin_Obukhov_similarity_function_for_heat
+  long_name = Monin-Obukhov similarity function for heat
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[xland]
+  standard_name = sea_land_ice_mask
+  long_name = sea land ice mask
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[hfx]
+  standard_name = kinematic_surface_upward_sensible_heat_flux
+  long_name = kinematic surface upward sensible heat flux
+  units = W m-2
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[qfx]
+  standard_name = kinematic_surface_upward_latent_heat_flux
+  long_name = kinematic surface upward latent heat flux
+  units = W m-2
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[wspd]
+  standard_name = wind_speed_at_lowest_model_layer
+  long_name = wind speed at lowest model layer
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[br]
+  standard_name = bulk_richardson_number_at_lowest_model_level
+  long_name = bulk richardson number at lowest model level
+  units = none 
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[dt]
+  standard_name = time_step_for_physics
+  long_name = time step for physics
+  units = s
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[kpbl1d]
+  standard_name = vertical_index_at_top_of_atmosphere_boundary_layer
+  long_name = vertical index at top of atmosphere boundary layer
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = integer
+  intent = out
+  optional = F
+[exch_hx]
+  standard_name = surface_exchange_coefficient_for_heat
+  long_name = surface exchange coefficient for heat
+  units = W m-2 K-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[exch_mx]
+  standard_name = surface_drag_wind_speed_for_momentum_in_air
+  long_name = surface drag wind speed for momentum in air
+  units =  m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[wstar]
+  standard_name = surface_wind_enhancement_due_to_convection
+  long_name = surface wind enhancement due to convection
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[delta]
+  standard_name = entrainment_layer_depth
+  long_name = entrainment layer depth
+  units =  m
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = out
+  optional = F
+[u10]
+  standard_name = x_wind_at_10m
+  long_name = x wind at 10m
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = inout
+  optional = F
+[v10]
+  standard_name = y_wind_at_10m
+  long_name = y wind at 10m
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = inout
+  optional = F
+[uox]
+  standard_name = x_ocean_surface_current_speed
+  long_name = x ocean surface current speed
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[vox]
+  standard_name = y_ocean_surface_current_speed
+  long_name = y ocean surface current speed
+  units = m s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[rthraten]
+  standard_name = tendency_of_potential_temperature_from_radiation
+  long_name = tendency of potential temperature from radiation
+  units = K s-1
+  dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = F
+[ysu_topdown_pblmix]
+  standard_name = ysu_mixing_flag
+  long_name = ysu mixing flag
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ctopo]
+  standard_name = correction_for_topography
+  long_name = correction for topography
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = T
+[ctopo2]
+  standard_name = correction_for_topography_2
+  long_name = correction for topography 2
+  units = none
+  dimensions = (horizontal_loop_start:horizontal_loop_end)
+  type = real | kind = kind_phys
+  intent = in
+  optional = T
+[its]
+  standard_name = horizontal_loop_start
+  long_name = horizontal loop start
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ite]
+  standard_name = horizontal_loop_end
+  long_name = horizontal loop end
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kts]
+  standard_name = vertical_layer_start
+  long_name = vertical layer start
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kte]
+  standard_name = vertical_layer_end
+  long_name = vertical layer end
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+[ccpp-arg-table]
+  name = bl_ysu_init
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+[ccpp-arg-table]
+  name = bl_ysu_finalize
+  type = scheme
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.meta
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.meta
@@ -14,7 +14,7 @@
   long_name = x wind
   units = m s-1
   dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
-  type = real | kind = kind_phys | kind = kind_phys
+  type = real | kind = kind_phys
   intent = in
   optional = F
 [vx]
@@ -22,7 +22,7 @@
   long_name = y wind
   units =  m s-1
   dimensions = (horizontal_loop_start:horizontal_loop_end,vertical_layer_start:vertical_layer_end)
-  type = real | kind = kind_phys | kind = kind_phys
+  type = real | kind = kind_phys
   intent = in
   optional = F
 [tx]
@@ -489,10 +489,26 @@
   type = integer
   intent = in
   optional = F
+[kms]
+  standard_name = vertical_interface_start
+  long_name = vertical interface start
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kme]
+  standard_name = vertical_interface_end
+  long_name = vertical interface end
+  units = none 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
-  units = none
+  units = 1
   dimensions = ()
   type = character
   kind = len=*
@@ -512,7 +528,7 @@
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
-  units = none
+  units = 1
   dimensions = ()
   type = character
   kind = len=*
@@ -532,7 +548,7 @@
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
-  units = none
+  units = 1
   dimensions = ()
   type = character
   kind = len=*


### PR DESCRIPTION
1. The routine calling the YSU scheme has access to the flag_qc
and flag_qi logicals. The flag_qi variable was passed into the
YSU scheme, not the flag_qc. The flag_qc variable was added to
the call. Now, both the flag_qc and flag_qi logicals are used
as arguments to the bl_ysu_run scheme. This is, conveniently,
also what the WRF group did in a separate repository.

2. The INTENT of a number of variables (znt, ust, hpbl, wspd,
all of the computed tendency arrays, wstar, and delta) were
determined based on the use in the bl_ysu_run routine. These
INTENTs were fixed in the bl_ysu_run and ysu routines. For
variables that are INTENT(OUT), remove all initializations. For
variables that are INTENT(IN), do not copy them back into the
MPAS variables.

3. Able to reproduce bit-for-bit results for 24-h simulation
on 40962 cells.

4. TBD: This version of the code should fit into WRF, but the
assumed chemistry array (qmix) needs to be optional in MPAS.
Not in the critical path.

5. The ctopo and ctopo2 arrays: WRF (both dy cores) and
MPAS include the arrays in the calling arguments. So, they do not
appear to need to be `optional`, and the `present` tests could 
be removed. Keeping them optional for eventual CESM/CAM usage.

6. For support of the CPF work, the two error arguments that
are required for the CPF-compliant routines (the error
message and the error flag) are passed through the call
chain to the bl_ysu_run routine. To verify that the arguments are 
passed correctly, a temporary print was included in atm_do_timestep. 
Each model time step printed out the following success
message based on the errflg value:
```
 Physics OK: bl_ysu_run OK
```

7. The metadata file associated with the `bl_ysu_run` scheme has been added as part
of the the repository. The `bl_ysu.meta` file is specifically set up to work with the
`bl_ysu_run` routine, not the outer `ysu` scheme.

modified:   src/core_atmosphere/mpas_atm_core.F
modified:   src/core_atmosphere/physics/mpas_atmphys_driver.F
modified:   src/core_atmosphere/physics/mpas_atmphys_driver_pbl.F
modified:   src/core_atmosphere/physics/physics_sima/bl_ysu.F

added:   src/core_atmosphere/physics/physics_sima/bl_ysu.meta