### PR TITLE
Remove back and forth theta -> temperature -> theta computation

### DIFF
--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -428,11 +428,6 @@ contains
          delta(i,j) = delta_hv(i)
       end do
 !
-     do k = kts,kte
-       do i = its,ite
-         rthblten(i,k,j) = rthblten(i,k,j)/pi3d(i,k,j)
-       enddo
-     enddo
 !
 !  call mpas_log_write(' ')
 !  call mpas_log_write('--- end subroutine bl_ysu_run:')
@@ -1386,9 +1381,9 @@ contains
 !
    do k = kte,kts,-1
      do i = its,ite
-       ttend = (f1(i,k)-thx(i,k)+300.)*rdt*pi2d(i,k)
+       ttend = (f1(i,k)-thx(i,k)+300.)*rdt
        ttnp(i,k) = ttend
-       dtsfc(i) = dtsfc(i)+ttend*cont*del(i,k)/pi2d(i,k)
+       dtsfc(i) = dtsfc(i)+ttend*cont*del(i,k)
      enddo
    enddo
 !


### PR DESCRIPTION
At the end of the ysu subroutine, this mod removes the computation
that switches the temperature tendency to a potential temperature
tendency.

We make that change because inside of the bl_ysu_run subroutine, we
removed the computation that changed the potential temperature
tendency to a temperature tendency.

At the end of the bl_ysu_run routine, we have a potential temperature
tendency. There is no need to temporarily convert this to a temperature
tendency, only to reconvert it back to a potential temperature
tendency immediately after the routine exits.

As expected, this change causes bit-for-bit differences. This change
was not included in the sequence of ysu mods that give bit-wise identical
results to allow the code to be validated more easily.

Both MPAS and WRF physics developers OK'ed this modification. Both
MPAS and WRF physics schemes expect to handle potential temperature
tendencies coming out of the PBL scheme from phyics.

Advantages:
1. No need to do reciprocal computations to get back to the same
state variable (algebraically the same).
2. The trailing computation in the ysu scheme (which is now removed)
would have required an extra CPF interstitial routine.

modified:   src/core_atmosphere/physics/physics_sima/bl_ysu.F