### PR TITLE
Fix broken YSU build due to CPF (attempt 2)

### DIFF
--- a/src/core_atmosphere/physics/physics_sima/Makefile
+++ b/src/core_atmosphere/physics/physics_sima/Makefile
@@ -6,7 +6,7 @@ dummy:
 	echo "****** compiling physics_sima ******"
 
 OBJS = \
-	bl_ysu.o                \
+	bl_ysu.o
 
 physics_sima: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)

--- a/src/core_atmosphere/physics/physics_sima/bl_ysu.F
+++ b/src/core_atmosphere/physics/physics_sima/bl_ysu.F
@@ -43,8 +43,8 @@ module bl_ysu
   PUBLIC :: bl_ysu_init
   PUBLIC :: bl_ysu_run
   PUBLIC :: bl_ysu_finalize
+  PUBLIC :: ysu
 
-  PRIVATE :: ysu
   PRIVATE :: tridi1n
   PRIVATE :: tridin_ysu
   PRIVATE :: get_pblh


### PR DESCRIPTION
In the physics/physics_sima/bl_ys.F file, the subroutine ysu
was incorrectly labeled as "private". It needs to be "public".

modified:   src/core_atmosphere/physics/physics_sima/Makefile
modified:   src/core_atmosphere/physics/physics_sima/bl_ysu.F